### PR TITLE
Fix small typo in `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,7 +131,7 @@ cargo bench
 Ensure that you have the `rustfmt-preview` component installed in `rustup`:
 
 ```
-rustup component add rustup-preview
+rustup component add rustfmt-preview
 ```
 
 To format all of the code in the crate, run


### PR DESCRIPTION
In a section about rustfmt there was small typo where it said`rustup-preview` instead of `rustfmt-preview`.